### PR TITLE
Unloads the target arch module before the next iteration

### DIFF
--- a/maali
+++ b/maali
@@ -1842,7 +1842,7 @@ if [ $MAALI_REMODULE -eq 0 ]; then
               module list
             fi # if [ $DEBUG ]; then
 
-            echo "MAALI_CPU_TARGET = $MAALI_CPU_TARGET"
+            maali_load_module "$MAALI_CPU_TARGET"
 
             if [ $DEBUG ]; then
               echo " .. after module load \$MAALI_CPU_TARGET"
@@ -1994,6 +1994,13 @@ if [ $MAALI_REMODULE -eq 0 ]; then
           done # for MAALI_TOOL_CUDA_COMPILER in $MAALI_TOOL_CUDA_COMPILERS; do
 
           # TODO unload module
+
+          if [ "$MAALI_CPU_TARGET" != "na" ]; then
+            # should we load some sort of module?
+
+            module unload "$MAALI_CPU_TARGET"
+
+          fi # if [ "$MAALI_CPU_TARGET" != "na" ]; then
 
         done # for MAALI_CPU_TARGET in $MAALI_TOOL_CPU_TARGET; do
   


### PR DESCRIPTION
Includes the 1.2.4 change of loading the module, as well as unloading the module.  If don't unload it gives a conflict on next iteration of the do loop