### PR TITLE
if a user specifies -h, it's not an error

### DIFF
--- a/maali
+++ b/maali
@@ -1110,7 +1110,7 @@ do
      case $OPTION in
          h)
              usage
-             exit 1
+             exit 0
              ;;
          t)
              MAALI_TOOL_NAME=$OPTARG


### PR DESCRIPTION
we shouldn't exit 0 if they get the command line correct

`aelwell@athena:~$ srun maali -h
usage: /pawsey/sles12sp2/tools/binary/maali/1.2.5/bin/maali -t toolname -v toolversion [-h] [-d] [-c maali config file] [-m] [-l] [-r compiler/version] [-b] [-g] [-s] [-w] [-a] [-u] [-x]

maali - Pawsey Supercomputing Centre Build System

OPTIONS:
   -t      tool name
   -v      tool version
   -h      show this message
   -d      run in debug mode
   -c      maali configuration file
   -m      just create the module file
   -l      create LUA modules
   -r      build with the specified compiler (and no others)
   -b      build the tool, but don't create a module file
   -g      group build in /group/pawsey0001/software/sles12sp2
   -s      activate system build
   -w      workstation build in /home/aelwell/software/sles12sp2
   -a      activate this version as the default version
   -f      force download from github
   -u      unistall by hiding the module
   -x      expunge tool from history
   -n      NVIDIA mode; compile software with cuda support
srun: error: a001: task 0: Exited with exit code 1`