### PR TITLE
Marco : added LIBRARY_PATH to lists of special cases for env variables

### DIFF
--- a/maali
+++ b/maali
@@ -807,6 +807,9 @@ EOF
           MAALI_MODULE_VARIABLE_TCL="append-path"
           MAALI_MODULE_VARIABLE_DIR="lib"
           ;;
+        LIBRARY_PATH)
+          MAALI_MODULE_VARIABLE_DIR="lib"
+          ;;
         CPATH | C_INCLUDE_PATH | CPLUS_INCLUDE_PATH | FPATH | FCPATH | INCLUDE_PATH | INTEL_INC_PATH )
           MAALI_MODULE_VARIABLE_DIR="include"
           ;;
@@ -1357,6 +1360,9 @@ EOF
         LD_LIBRARY_PATH_APPEND)
           MAALI_MODULE_VARIABLE_NAME='LD_LIBRARY_PATH'
           MAALI_MODULE_VARIABLE_LUA="append_path"
+          MAALI_MODULE_VARIABLE_DIR="lib"
+          ;;
+        LIBRARY_PATH)
           MAALI_MODULE_VARIABLE_DIR="lib"
           ;;
         CPATH | C_INCLUDE_PATH | CPLUS_INCLUDE_PATH | FPATH | FCPATH | INCLUDE_PATH | INTEL_INC_PATH )


### PR DESCRIPTION
The key difference compared to the existing behaviour, apart from the default "lib" string value, is that prepend-path will be used for LIBRARY_PATH rather than append. This is useful as LIBRARY_PATH might be modified by multiple system modules (compiler, scientific libraries, ..).
