### PR TITLE
Marco: a couple of options for customising environment variables during module creation

### DIFF
--- a/maali
+++ b/maali
@@ -795,6 +795,8 @@ EOF
           # TODO: get perl version from perl
           MAALI_MODULE_VARIABLE_DIR="lib/perl5/site_perl/5.10.1"
           ;;
+        CLASSPATH)
+          ;;
         INTEL_PATH)
           ;;
         R_LIBS)
@@ -806,6 +808,8 @@ EOF
           MAALI_MODULE_VARIABLE_NAME='LD_LIBRARY_PATH'
           MAALI_MODULE_VARIABLE_TCL="append-path"
           MAALI_MODULE_VARIABLE_DIR="lib"
+          ;;
+        MIC_LD_LIBRARY_PATH)
           ;;
         LIBRARY_PATH)
           MAALI_MODULE_VARIABLE_DIR="lib"
@@ -821,6 +825,8 @@ EOF
           ;;
         MANPATH)
           MAALI_MODULE_VARIABLE_DIR="share/man"
+          ;;
+        NLSPATH)
           ;;
         OMP_NUM_THREADS | MKL_NUM_THREADS)
           MAALI_MODULE_VARIABLE_DIR=${!MAALI_MODULE_VARIABLE}
@@ -1350,6 +1356,8 @@ EOF
           # TODO: get perl version from perl
           MAALI_MODULE_VARIABLE_DIR="lib/perl5/site_perl/5.10.1"
           ;;
+        CLASSPATH)
+          ;;
         INTEL_PATH)
           ;;
         R_LIBS)
@@ -1361,6 +1369,8 @@ EOF
           MAALI_MODULE_VARIABLE_NAME='LD_LIBRARY_PATH'
           MAALI_MODULE_VARIABLE_LUA="append_path"
           MAALI_MODULE_VARIABLE_DIR="lib"
+          ;;
+        MIC_LD_LIBRARY_PATH)
           ;;
         LIBRARY_PATH)
           MAALI_MODULE_VARIABLE_DIR="lib"
@@ -1376,6 +1386,8 @@ EOF
           ;;
         MANPATH)
           MAALI_MODULE_VARIABLE_DIR="share/man"
+          ;;
+        NLSPATH)
           ;;
         OMP_NUM_THREADS | MKL_NUM_THREADS)
           MAALI_MODULE_VARIABLE_DIR=${!MAALI_MODULE_VARIABLE}

--- a/maali
+++ b/maali
@@ -772,16 +772,14 @@ EOF
     MAALI_MODULE_VARIABLE_PREPREND="$MAALI_APP_HOME/"
     MAALI_MODULE_VARIABLE_TCL="prepend-path"
 
-    MAALI_MODULE_VARIABLE_PREPREND_OFF="MAALI_MODULE_PREPEND_${MAALI_MODULE_VARIABLE_NAME}"
-    MAALI_MODULE_VARIABLE_PREPREND_OFF_VALUE=`eval echo "${!MAALI_MODULE_VARIABLE_PREPREND_OFF}"`
+    MAALI_MODULE_VARIABLE_PREPREND_SWITCH="MAALI_MODULE_PREPEND_${MAALI_MODULE_VARIABLE_NAME}"
+    MAALI_MODULE_VARIABLE_PREPREND_SWITCH_VALUE=`eval echo "${!MAALI_MODULE_VARIABLE_PREPREND_SWITCH}"`
+
+    MAALI_MODULE_VARIABLE_TYPE="MAALI_MODULE_TYPE_${MAALI_MODULE_VARIABLE_NAME}"
+    MAALI_MODULE_VARIABLE_TYPE_VALUE=`eval echo "${!MAALI_MODULE_VARIABLE_TYPE}"`
 
     MAALI_MODULE_VARIABLE_LIST_OFF="MAALI_MODULE_LIST_${MAALI_MODULE_VARIABLE_NAME}"
     MAALI_MODULE_VARIABLE_LIST_OFF_VALUE=`eval echo "${!MAALI_MODULE_VARIABLE_LIST_OFF}"`
-
-    # turn the prepending off
-    if [ "$MAALI_MODULE_VARIABLE_PREPREND_OFF_VALUE" == "off" ]; then
-      MAALI_MODULE_VARIABLE_PREPREND=""
-    fi
 
     if [ "${!MAALI_MODULE_VARIABLE}" != "" ]; then
       case $MAALI_MODULE_VARIABLE_NAME in
@@ -795,8 +793,6 @@ EOF
           # TODO: get perl version from perl
           MAALI_MODULE_VARIABLE_DIR="lib/perl5/site_perl/5.10.1"
           ;;
-        CLASSPATH)
-          ;;
         INTEL_PATH)
           ;;
         R_LIBS)
@@ -808,8 +804,6 @@ EOF
           MAALI_MODULE_VARIABLE_NAME='LD_LIBRARY_PATH'
           MAALI_MODULE_VARIABLE_TCL="append-path"
           MAALI_MODULE_VARIABLE_DIR="lib"
-          ;;
-        MIC_LD_LIBRARY_PATH)
           ;;
         LIBRARY_PATH)
           MAALI_MODULE_VARIABLE_DIR="lib"
@@ -825,8 +819,6 @@ EOF
           ;;
         MANPATH)
           MAALI_MODULE_VARIABLE_DIR="share/man"
-          ;;
-        NLSPATH)
           ;;
         OMP_NUM_THREADS | MKL_NUM_THREADS)
           MAALI_MODULE_VARIABLE_DIR=${!MAALI_MODULE_VARIABLE}
@@ -857,6 +849,23 @@ EOF
           MAALI_MODULE_VARIABLE_PREPREND=""
           ;;
         esac
+
+        # turn the prepending on/off
+        if [ "$MAALI_MODULE_VARIABLE_PREPREND_SWITCH_VALUE" == "off" ]; then
+          MAALI_MODULE_VARIABLE_PREPREND=""
+        elif [ "$MAALI_MODULE_VARIABLE_PREPREND_SWITCH_VALUE" == "on" ]; then
+          MAALI_MODULE_VARIABLE_PREPREND="$MAALI_APP_HOME/"
+        fi
+
+        # change type of variable declaration
+        if [ "$MAALI_MODULE_VARIABLE_TYPE_VALUE" == "prepend" ]; then
+          MAALI_MODULE_VARIABLE_TCL="prepend-path"
+        elif [ "$MAALI_MODULE_VARIABLE_TYPE_VALUE" == "append" ]; then
+          MAALI_MODULE_VARIABLE_TCL="append-path"
+        elif [ "$MAALI_MODULE_VARIABLE_TYPE_VALUE" == "setenv" ]; then
+          MAALI_MODULE_VARIABLE_TCL="setenv"
+        fi
+
         # don't treat value as a list
         if [ "$MAALI_MODULE_VARIABLE_LIST_OFF_VALUE" == "off" ]; then
           MAALI_MODULE_VARIABLE_WORDS="1"
@@ -1333,16 +1342,14 @@ EOF
     MAALI_MODULE_VARIABLE_PREPREND="$MAALI_APP_HOME/"
     MAALI_MODULE_VARIABLE_LUA="prepend_path"
 
-    MAALI_MODULE_VARIABLE_PREPREND_OFF="MAALI_MODULE_PREPEND_${MAALI_MODULE_VARIABLE_NAME}"
-    MAALI_MODULE_VARIABLE_PREPREND_OFF_VALUE=`eval echo "${!MAALI_MODULE_VARIABLE_PREPREND_OFF}"`
+    MAALI_MODULE_VARIABLE_PREPREND_SWITCH="MAALI_MODULE_PREPEND_${MAALI_MODULE_VARIABLE_NAME}"
+    MAALI_MODULE_VARIABLE_PREPREND_SWITCH_VALUE=`eval echo "${!MAALI_MODULE_VARIABLE_PREPREND_SWITCH}"`
+
+    MAALI_MODULE_VARIABLE_TYPE="MAALI_MODULE_TYPE_${MAALI_MODULE_VARIABLE_NAME}"
+    MAALI_MODULE_VARIABLE_TYPE_VALUE=`eval echo "${!MAALI_MODULE_VARIABLE_TYPE}"`
 
     MAALI_MODULE_VARIABLE_LIST_OFF="MAALI_MODULE_LIST_${MAALI_MODULE_VARIABLE_NAME}"
     MAALI_MODULE_VARIABLE_LIST_OFF_VALUE=`eval echo "${!MAALI_MODULE_VARIABLE_LIST_OFF}"`
-
-    # turn the prepending off
-    if [ "$MAALI_MODULE_VARIABLE_PREPREND_OFF_VALUE" == "off" ]; then
-      MAALI_MODULE_VARIABLE_PREPREND=""
-    fi
 
     if [ "${!MAALI_MODULE_VARIABLE}" != "" ]; then
       case $MAALI_MODULE_VARIABLE_NAME in
@@ -1356,8 +1363,6 @@ EOF
           # TODO: get perl version from perl
           MAALI_MODULE_VARIABLE_DIR="lib/perl5/site_perl/5.10.1"
           ;;
-        CLASSPATH)
-          ;;
         INTEL_PATH)
           ;;
         R_LIBS)
@@ -1369,8 +1374,6 @@ EOF
           MAALI_MODULE_VARIABLE_NAME='LD_LIBRARY_PATH'
           MAALI_MODULE_VARIABLE_LUA="append_path"
           MAALI_MODULE_VARIABLE_DIR="lib"
-          ;;
-        MIC_LD_LIBRARY_PATH)
           ;;
         LIBRARY_PATH)
           MAALI_MODULE_VARIABLE_DIR="lib"
@@ -1386,8 +1389,6 @@ EOF
           ;;
         MANPATH)
           MAALI_MODULE_VARIABLE_DIR="share/man"
-          ;;
-        NLSPATH)
           ;;
         OMP_NUM_THREADS | MKL_NUM_THREADS)
           MAALI_MODULE_VARIABLE_DIR=${!MAALI_MODULE_VARIABLE}
@@ -1418,6 +1419,23 @@ EOF
           MAALI_MODULE_VARIABLE_PREPREND=""
           ;;
         esac
+
+        # turn the prepending on/off
+        if [ "$MAALI_MODULE_VARIABLE_PREPREND_SWITCH_VALUE" == "off" ]; then
+          MAALI_MODULE_VARIABLE_PREPREND=""
+        elif [ "$MAALI_MODULE_VARIABLE_PREPREND_SWITCH_VALUE" == "on" ]; then
+          MAALI_MODULE_VARIABLE_PREPREND="$MAALI_APP_HOME/"
+        fi
+
+        # change type of variable declaration
+        if [ "$MAALI_MODULE_VARIABLE_TYPE_VALUE" == "prepend" ]; then
+          MAALI_MODULE_VARIABLE_LUA="prepend-path"
+        elif [ "$MAALI_MODULE_VARIABLE_TYPE_VALUE" == "append" ]; then
+          MAALI_MODULE_VARIABLE_LUA="append-path"
+        elif [ "$MAALI_MODULE_VARIABLE_TYPE_VALUE" == "setenv" ]; then
+          MAALI_MODULE_VARIABLE_LUA="setenv"
+        fi
+
         # don't treat value as a list
         if [ "$MAALI_MODULE_VARIABLE_LIST_OFF_VALUE" == "off" ]; then
           MAALI_MODULE_VARIABLE_WORDS="1"


### PR DESCRIPTION
- modification: MAALI_MODULE_PREPEND_VARNAME= on/off , to switch on/off the prepending of MAALI_INSTALL_DIR, after all the defaults are applied ; previously, only off was available, and setting was applied after the general default but before the defaults for specific variable names
- new feature: MAALI_MODULE_TYPE_VARNAME= prepend/append/setenv , to control the way variable values interact with preexisting values for the same variable name; again, this is applied after all the defaults.

I think these two mods allow for useful flexibility in defining the environment variables for modules. 

Testing: successfully done.

Incompatibilities: none. New variable settings would be ignored by previous maali versions. None of the existing cyg files are affected by the little change in the order settings are applied compared to the default settings.

